### PR TITLE
Add support for Sensor Sensitivity in Silvair-UART-Decoder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="silvair-uart-decoder",
-    version="0.1.4",
+    version="0.1.5",
     packages=find_packages(),
     license='MIT',
     entry_points={

--- a/silvair_uart_decoder/LogicExtension/extension.json
+++ b/silvair_uart_decoder/LogicExtension/extension.json
@@ -2,7 +2,7 @@
   "name": "Silvair UART Decoder",
   "apiVersion": "1.0.0",
   "author": "Silvair",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "",
   "extensions": {
     "Silvair UART Decoder": {

--- a/silvair_uart_decoder/uart_protocol/adapters.py
+++ b/silvair_uart_decoder/uart_protocol/adapters.py
@@ -4,7 +4,8 @@ from .formatters import enum_model_name_fmter, enum_opcode_name_fmter, enum_atte
     enum_dfu_status_fmter, enum_dfu_state_fmter, enum_error_id_fmter, list_fmter, struct_fmter, data_hexstr_fmter, \
     data_ascii_fmter, uuid_fmter, uint8_hex_fmter, uint16_hex_fmter, uint32_hex_fmter, uint8_hex_and_int_fmter, \
     uint16_hex_and_int_fmter, uint32_hex_and_int_fmter, rtc_date_fmter, mesh_date_fmter, \
-    enum_meshmesreq1_opcode_name_fmter, enum_el_state_fmter, enum_property_id_fmter, enum_test_status_fmter
+    enum_meshmesreq1_opcode_name_fmter, enum_el_state_fmter, enum_property_id_fmter, enum_test_status_fmter, \
+    enum_setting_name_fmter, enum_access_name_fmter
 
 
 class ValueObj:
@@ -67,10 +68,24 @@ class ModelIdAdapter(Adapter):
     def _decode(self, obj, context, path):
         return ValueObj(obj, enum_model_name_fmter)
 
+
+class AccessAdapter(Adapter):
+
+    def _decode(self, obj, context, path):
+        return ValueObj(obj, enum_access_name_fmter)
+
+
+class SettingIdAdapter(Adapter):
+
+    def _decode(self, obj, context, path):
+        return ValueObj(obj, enum_setting_name_fmter)
+
+
 class ELStateAdapter(Adapter):
 
     def _decode(self, obj, context, path):
         return ValueObj(obj, enum_el_state_fmter)
+
 
 class ELPropertyIDAdapter(Adapter):
 

--- a/silvair_uart_decoder/uart_protocol/common.py
+++ b/silvair_uart_decoder/uart_protocol/common.py
@@ -46,6 +46,8 @@ class CommandCode(enum.IntEnum):
     TimeSourceGetResponse = 0x2C
     TimeGetRequest = 0x2D
     TimeGetResponse = 0x2E
+    SensorSettingUpdateRequest = 0x2F
+    SensorSettingUpdateResponse = 0x30
     DfuInitRequest = 0x80
     DfuInitResponse = 0x81
     DfuStatusRequest = 0x82
@@ -118,6 +120,16 @@ class PropertyID(enum.IntEnum):
 class TestStatus(enum.IntEnum):
     Test_Finished = 0x00
     Test_Result_Unknown = 0x07
+
+
+class AccessName(enum.IntEnum):
+    Read_Only = 0x01
+    Read_Write = 0x03
+
+
+class SettingName(enum.IntEnum):
+    Sensor_Sensitivity = 0xFF90
+    Sensor_Sensitivity_Steps = 0xFF91
 
 
 class ModelName(enum.IntEnum):

--- a/silvair_uart_decoder/uart_protocol/formatters.py
+++ b/silvair_uart_decoder/uart_protocol/formatters.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import timedelta, datetime, timezone
 
 from .common import AttentionState, DeviceState, ErrorId, DFUStatus, DFUState, ModelName, OpcodeName, ELState, \
-    PropertyID, TestStatus
+    PropertyID, TestStatus, SettingName, AccessName
 
 UINT8_FMT = "0x{:02x}"
 UINT16_FMT = "0x{:04x}"
@@ -47,6 +47,14 @@ def enum_fmter(value, fmt="{}", enum_base=None):
 
 def enum_model_name_fmter(value):
     return enum_fmter(value, UINT16_FMT, ModelName)
+
+
+def enum_access_name_fmter(value):
+    return enum_fmter(value, UINT8_FMT, AccessName)
+
+
+def enum_setting_name_fmter(value):
+    return enum_fmter(value, UINT16_FMT, SettingName)
 
 
 def enum_opcode_name_fmter(value):
@@ -91,6 +99,7 @@ def enum_property_id_fmter(value):
 
 def enum_test_status_fmter(value):
     return enum_fmter(value, UINT8_FMT, TestStatus)
+
 
 def list_fmter(value):
     return "[{}]".format(", ".join([str(v) for v in value]))

--- a/silvair_uart_decoder/uart_protocol/test_parsers.py
+++ b/silvair_uart_decoder/uart_protocol/test_parsers.py
@@ -3,7 +3,7 @@ import unittest
 from .parsers import ModelId, ModelIds, Attention, Data, DFUPageCreateReq, DeviceState, Error, DFUStatus, \
     DFUState, UUID, Version, HealthFaultParams, HealthTestParams, MeshMessageReq, MeshMessageResp, SensorUpdateReq, \
     DFUInitReq, DFUStatusResp, HealthServerParams, SensorParams, SensorServerParams, ModelParams, TimeGetResp, \
-    TimeSourceGetResp, MeshMessageReq1
+    TimeSourceGetResp, MeshMessageReq1, SensorSettingValue, SenSetUpdateReq
 
 
 class ParsersTest(unittest.TestCase):
@@ -139,6 +139,7 @@ class ParsersTest(unittest.TestCase):
         data = bytes([0x01, 0x4d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x40])
 
         result = SensorServerParams.parse(data)
+        self.assertEqual(0, result.value.setting_count)
         self.assertEqual(1, result.value.sensor_count)
         self.assertEqual(0x004d, result.value.sensors.value[0].value.property_id.value)
         self.assertEqual(0x0000, result.value.sensors.value[0].value.positive_tolerance.value)
@@ -146,6 +147,78 @@ class ParsersTest(unittest.TestCase):
         self.assertEqual(0x01, result.value.sensors.value[0].value.sampling_function.value)
         self.assertEqual(0x00, result.value.sensors.value[0].value.measurement_period.value)
         self.assertEqual(0x40, result.value.sensors.value[0].value.update_interval.value)
+
+    def test_should_parse_CreateInstancesRequestWithSensorSettings(self):
+        data = bytes([0x00, 0x11, 0x21, 0x4D, 0x00, 0x00, 0x00, 0x00,
+                      0x00, 0x01, 0x00, 0x2F, 0x4D, 0x00, 0x03, 0x90,
+                      0xFF, 0xC8, 0x4D, 0x00, 0x01, 0x91, 0xFF, 0xC8,
+                      0x00, 0x11, 0x01, 0x4E, 0x00, 0x00, 0x00, 0x00,
+                      0x00, 0x01, 0x00, 0x2F, 0x00, 0x11, 0x02, 0x57,
+                      0x00, 0x14, 0x00, 0x14, 0x00, 0x03, 0x00, 0x40,
+                      0x6A, 0x00, 0x28, 0x00, 0x28, 0x00, 0x03, 0x00,
+                      0x40, 0x00, 0x11, 0x02, 0x59, 0x00, 0x14, 0x00,
+                      0x14, 0x00, 0x03, 0x00, 0x40, 0x52, 0x00, 0x28,
+                      0x00, 0x28, 0x00, 0x03, 0x00, 0x40])
+        result = ModelParams.parse(data)
+        self.assertEqual(0x1100, result.value[0].value.model_id.value)
+        self.assertEqual(2, result.value[0].value.params.value.setting_count)
+        self.assertEqual(1, result.value[0].value.params.value.sensor_count)
+        self.assertEqual(0x004d, result.value[0].value.params.value.sensors.value[0].value.property_id.value)
+        self.assertEqual(0x0000, result.value[0].value.params.value.sensors.value[0].value.positive_tolerance.value)
+        self.assertEqual(0x0000, result.value[0].value.params.value.sensors.value[0].value.negative_tolerance.value)
+        self.assertEqual(0x01, result.value[0].value.params.value.sensors.value[0].value.sampling_function.value)
+        self.assertEqual(0x00, result.value[0].value.params.value.sensors.value[0].value.measurement_period.value)
+        self.assertEqual(0x2F, result.value[0].value.params.value.sensors.value[0].value.update_interval.value)
+        self.assertEqual(0x004d, result.value[0].value.params.value.settings.value[0].value.model_id)
+        self.assertEqual(0x03, result.value[0].value.params.value.settings.value[0].value.access)
+        self.assertEqual(0xff90, result.value[0].value.params.value.settings.value[0].value.setting_id)
+        self.assertEqual(200, result.value[0].value.params.value.settings.value[0].value.setting_value)
+        self.assertEqual(0x004d, result.value[0].value.params.value.settings.value[1].value.model_id)
+        self.assertEqual(0x01, result.value[0].value.params.value.settings.value[1].value.access)
+        self.assertEqual(0xff91, result.value[0].value.params.value.settings.value[1].value.setting_id)
+        self.assertEqual(200, result.value[0].value.params.value.settings.value[1].value.setting_value)
+
+        self.assertEqual(0x1100, result.value[1].value.model_id.value)
+        self.assertEqual(0, result.value[1].value.params.value.setting_count)
+        self.assertEqual(1, result.value[1].value.params.value.sensor_count)
+        self.assertEqual(0x004e, result.value[1].value.params.value.sensors.value[0].value.property_id.value)
+        self.assertEqual(0x0000, result.value[1].value.params.value.sensors.value[0].value.positive_tolerance.value)
+        self.assertEqual(0x0000, result.value[1].value.params.value.sensors.value[0].value.negative_tolerance.value)
+        self.assertEqual(0x01, result.value[1].value.params.value.sensors.value[0].value.sampling_function.value)
+        self.assertEqual(0x00, result.value[1].value.params.value.sensors.value[0].value.measurement_period.value)
+        self.assertEqual(0x2F, result.value[1].value.params.value.sensors.value[0].value.update_interval.value)
+
+        self.assertEqual(0x1100, result.value[2].value.model_id.value)
+        self.assertEqual(0, result.value[2].value.params.value.setting_count)
+        self.assertEqual(2, result.value[2].value.params.value.sensor_count)
+        self.assertEqual(0x0057, result.value[2].value.params.value.sensors.value[0].value.property_id.value)
+        self.assertEqual(0x0014, result.value[2].value.params.value.sensors.value[0].value.positive_tolerance.value)
+        self.assertEqual(0x0014, result.value[2].value.params.value.sensors.value[0].value.negative_tolerance.value)
+        self.assertEqual(0x03, result.value[2].value.params.value.sensors.value[0].value.sampling_function.value)
+        self.assertEqual(0x00, result.value[2].value.params.value.sensors.value[0].value.measurement_period.value)
+        self.assertEqual(0x40, result.value[2].value.params.value.sensors.value[0].value.update_interval.value)
+        self.assertEqual(0x006a, result.value[2].value.params.value.sensors.value[1].value.property_id.value)
+        self.assertEqual(0x0028, result.value[2].value.params.value.sensors.value[1].value.positive_tolerance.value)
+        self.assertEqual(0x0028, result.value[2].value.params.value.sensors.value[1].value.negative_tolerance.value)
+        self.assertEqual(0x03, result.value[2].value.params.value.sensors.value[1].value.sampling_function.value)
+        self.assertEqual(0x00, result.value[2].value.params.value.sensors.value[1].value.measurement_period.value)
+        self.assertEqual(0x40, result.value[2].value.params.value.sensors.value[1].value.update_interval.value)
+
+        self.assertEqual(0x1100, result.value[3].value.model_id.value)
+        self.assertEqual(0, result.value[3].value.params.value.setting_count)
+        self.assertEqual(2, result.value[3].value.params.value.sensor_count)
+        self.assertEqual(0x0059, result.value[3].value.params.value.sensors.value[0].value.property_id.value)
+        self.assertEqual(0x0014, result.value[3].value.params.value.sensors.value[0].value.positive_tolerance.value)
+        self.assertEqual(0x0014, result.value[3].value.params.value.sensors.value[0].value.negative_tolerance.value)
+        self.assertEqual(0x03, result.value[3].value.params.value.sensors.value[0].value.sampling_function.value)
+        self.assertEqual(0x00, result.value[3].value.params.value.sensors.value[0].value.measurement_period.value)
+        self.assertEqual(0x40, result.value[3].value.params.value.sensors.value[0].value.update_interval.value)
+        self.assertEqual(0x0052, result.value[3].value.params.value.sensors.value[1].value.property_id.value)
+        self.assertEqual(0x0028, result.value[3].value.params.value.sensors.value[1].value.positive_tolerance.value)
+        self.assertEqual(0x0028, result.value[3].value.params.value.sensors.value[1].value.negative_tolerance.value)
+        self.assertEqual(0x03, result.value[3].value.params.value.sensors.value[1].value.sampling_function.value)
+        self.assertEqual(0x00, result.value[3].value.params.value.sensors.value[1].value.measurement_period.value)
+        self.assertEqual(0x40, result.value[3].value.params.value.sensors.value[1].value.update_interval.value)
 
     def test_should_parse_ModelParams(self):
         data = bytes([0x0f, 0x13, 0x00, 0x11, 0x01, 0x4d, 0x00, 0x00,
@@ -156,6 +229,8 @@ class ParsersTest(unittest.TestCase):
         self.assertEqual(0x130f, result.value[0].value.model_id.value)
         self.assertEqual(None, result.value[0].value.params)
         self.assertEqual(0x1100, result.value[1].value.model_id.value)
+        self.assertEqual(0, result.value[1].value.params.value.setting_count)
+        self.assertEqual(1, result.value[1].value.params.value.sensor_count)
         self.assertEqual(0x004d, result.value[1].value.params.value.sensors.value[0].value.property_id.value)
         self.assertEqual(0x0000, result.value[1].value.params.value.sensors.value[0].value.positive_tolerance.value)
         self.assertEqual(0x0000, result.value[1].value.params.value.sensors.value[0].value.negative_tolerance.value)
@@ -277,7 +352,6 @@ class ParsersTest(unittest.TestCase):
         self.assertEqual(0xFF80, result.value.mesh_cmd.value.property_id)
         self.assertEqual(0x1234, result.value.mesh_cmd.value.property_value)
 
-
     def test_should_parse_EL_message_ELOperationalTimeStatus(self):
         data = bytes([0x01, 0x02, 0xEA, 0x36, 0x01, 0x0D, 0x67, 0x45, 0x23, 0x01, 0xEF, 0xCD, 0xAB, 0x89])
         result = MeshMessageReq1.parse(data)
@@ -346,4 +420,26 @@ class ParsersTest(unittest.TestCase):
         self.assertEqual(True, result.value.mesh_cmd.value.result.Battery_duration_fault)
         self.assertEqual(0x1234, result.value.mesh_cmd.value.test_length)
 
+    def test_should_parse_SensorSettingValue(self):
+        data = bytes([0x4D, 0x00, 0x03, 0x90, 0xFF, 0xC8])
+        result = SensorSettingValue.parse(data)
+        self.assertEqual(0x004d, result.value.model_id)
+        self.assertEqual(0x03, result.value.access)
+        self.assertEqual(0xff90, result.value.setting_id)
+        self.assertEqual(200, result.value.setting_value)
 
+    def test_should_parse_SensorSettingValue2(self):
+        data = bytes([0x4D, 0x00, 0x01, 0x91, 0xFF, 0x0A])
+        result = SensorSettingValue.parse(data)
+        self.assertEqual(0x004d, result.value.model_id)
+        self.assertEqual(0x01, result.value.access)
+        self.assertEqual(0xff91, result.value.setting_id)
+        self.assertEqual(10, result.value.setting_value)
+
+    def test_should_parse_SensorSettingUpdateRequest(self):
+        data = bytes([0x01, 0x4D, 0x00, 0x90, 0xFF, 0xC8])
+        result = SenSetUpdateReq.parse(data)
+        self.assertEqual(1, result.value.instance_index)
+        self.assertEqual(0x004D, result.value.property_id)
+        self.assertEqual(0xff90, result.value.setting_id)
+        self.assertEqual(200, result.value.setting_value)


### PR DESCRIPTION
Add support for SensorSettingUpdateRequest, SensorSettingUpdateResponse
Add support for sensors setting CreateInstancesRequest:
```
(model_id : 0x1100 (Sensor_Server), 
params : (setting_count : 2, sensor_count : 1, 
sensors : [
(property_id : 0x004d, positive_tolerance : 0x0000, negative_tolerance : 0x0000, sampling_function : 0x01, measurement_period : 0x00, update_interval : 0x2f)
], 
settings : [
(model_id : 0x004d, access : 0x03 (Read_Write), setting_id : 0xff90 (Sensor_Sensitivity), setting_value : 200), 
(model_id : 0x004d, access : 0x01 (Read_Only), setting_id : 0xff91 (Sensor_Sensitivity_Steps), setting_value : 200)
]
)), 
```